### PR TITLE
buffruneio: make 4X faster by using slice instead of container/list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![Tests Status](https://travis-ci.org/pelletier/go-buffruneio.svg?branch=master)](https://travis-ci.org/pelletier/go-buffruneio)
 [![GoDoc](https://godoc.org/github.com/pelletier/go-buffruneio?status.svg)](https://godoc.org/github.com/pelletier/go-buffruneio)
 
-Buffruneio is a wrapper around bufio to provide buffered runes access with
-unlimited unreads.
+Buffruneio provides rune-based buffered input.
 
 ```go
 import "github.com/pelletier/go-buffruneio"

--- a/buffruneio.go
+++ b/buffruneio.go
@@ -1,117 +1,133 @@
-// Package buffruneio is a wrapper around bufio to provide buffered runes access with unlimited unreads.
+// Package buffruneio provides rune-based buffered input.
 package buffruneio
 
 import (
 	"bufio"
-	"container/list"
 	"errors"
 	"io"
+	"unicode/utf8"
 )
 
-// Rune to indicate end of file.
-const (
-	EOF = -(iota + 1)
-)
+// EOF is a rune value indicating end-of-file.
+const EOF = -1
 
-// ErrNoRuneToUnread is returned by UnreadRune() when the read index is already at the beginning of the buffer.
+// ErrNoRuneToUnread is the error returned when UnreadRune is called with nothing to unread.
 var ErrNoRuneToUnread = errors.New("no rune to unwind")
 
-// Reader implements runes buffering for an io.Reader object.
+// A Reader implements rune-based input for an underlying byte stream.
 type Reader struct {
-	buffer  *list.List
-	current *list.Element
+	buffer  []rune
+	current int
 	input   *bufio.Reader
 }
 
-// NewReader returns a new Reader.
-func NewReader(rd io.Reader) *Reader {
+// NewReader returns a new Reader reading the given input.
+func NewReader(input io.Reader) *Reader {
 	return &Reader{
-		buffer: list.New(),
-		input:  bufio.NewReader(rd),
+		input: bufio.NewReader(input),
 	}
 }
 
-type runeWithSize struct {
-	r    rune
-	size int
-}
+// The rune buffer stores -2 to represent RuneError of length 1 (UTF-8 decoding errors).
+const badRune = -2
 
+// feedBuffer adds a rune to the buffer.
+// If EOF is reached, it adds EOF to the buffer and returns nil.
+// If a different error is encountered, it returns the error without
+// adding to the buffer.
 func (rd *Reader) feedBuffer() error {
+	if rd.buffer == nil {
+		rd.buffer = make([]rune, 0, 256)
+	}
 	r, size, err := rd.input.ReadRune()
-
 	if err != nil {
 		if err != io.EOF {
 			return err
 		}
 		r = EOF
 	}
-
-	newRuneWithSize := runeWithSize{r, size}
-
-	rd.buffer.PushBack(newRuneWithSize)
-	if rd.current == nil {
-		rd.current = rd.buffer.Back()
+	if r == utf8.RuneError && size == 1 {
+		r = badRune
 	}
+	rd.buffer = append(rd.buffer, r)
 	return nil
 }
 
-// ReadRune reads the next rune from buffer, or from the underlying reader if needed.
+// ReadRune reads and returns the next rune from the input.
+// The rune is also saved in an internal buffer, in case UnreadRune is called.
+// To avoid unbounded buffer growth, the caller must call Forget at appropriate intervals.
+//
+// At end of file, ReadRune returns EOF, 0, nil.
+// On read errors other than io.EOF, ReadRune returns EOF, 0, err.
 func (rd *Reader) ReadRune() (rune, int, error) {
-	if rd.current == rd.buffer.Back() || rd.current == nil {
-		err := rd.feedBuffer()
-		if err != nil {
+	if rd.current >= len(rd.buffer) {
+		if err := rd.feedBuffer(); err != nil {
 			return EOF, 0, err
 		}
 	}
-
-	runeWithSize := rd.current.Value.(runeWithSize)
-	rd.current = rd.current.Next()
-	return runeWithSize.r, runeWithSize.size, nil
+	r := rd.buffer[rd.current]
+	rd.current++
+	if r == badRune {
+		return utf8.RuneError, 1, nil
+	}
+	if r == EOF {
+		return EOF, 0, nil
+	}
+	return r, utf8.RuneLen(r), nil
 }
 
-// UnreadRune pushes back the previously read rune in the buffer, extending it if needed.
+// UnreadRune rewinds the input by one rune, undoing the effect of a single ReadRune call.
+// UnreadRune may be called multiple times to rewind a sequence of ReadRune calls,
+// up to the last time Forget was called or the beginning of the input.
+//
+// If there are no ReadRune calls left to undo, UnreadRune returns ErrNoRuneToUnread.
 func (rd *Reader) UnreadRune() error {
-	if rd.current == rd.buffer.Front() {
+	if rd.current == 0 {
 		return ErrNoRuneToUnread
 	}
-	if rd.current == nil {
-		rd.current = rd.buffer.Back()
-	} else {
-		rd.current = rd.current.Prev()
-	}
+	rd.current--
 	return nil
 }
 
-// Forget removes runes stored before the current stream position index.
+// Forget discards buffered runes before the current input position.
+// Calling Forget makes it impossible to UnreadRune earlier than the current input position
+// but is necessary to avoid unbounded buffer growth.
 func (rd *Reader) Forget() {
-	if rd.current == nil {
-		rd.current = rd.buffer.Back()
-	}
-	for ; rd.current != rd.buffer.Front(); rd.buffer.Remove(rd.current.Prev()) {
-	}
+	n := copy(rd.buffer, rd.buffer[rd.current:])
+	rd.current = 0
+	rd.buffer = rd.buffer[:n]
 }
 
-// PeekRune returns at most the next n runes, reading from the uderlying source if
-// needed. Does not move the current index. It includes EOF if reached.
+// PeekRune returns the next n runes in the input,
+// without advancing the current input position.
+//
+// If the input has fewer than n runes and then returns
+// an io.EOF error, PeekRune returns a slice containing
+// the available runes followed by EOF.
+// On other hand, if the input ends early with a non-io.EOF error,
+// PeekRune returns a slice containing only the available runes,
+// with no terminating EOF.
 func (rd *Reader) PeekRunes(n int) []rune {
-	res := make([]rune, 0, n)
-	cursor := rd.current
-	for i := 0; i < n; i++ {
-		if cursor == nil {
-			err := rd.feedBuffer()
-			if err != nil {
-				return res
-			}
-			cursor = rd.buffer.Back()
+	for len(rd.buffer)-rd.current < n && !rd.haveEOF() {
+		if err := rd.feedBuffer(); err != nil {
+			break
 		}
-		if cursor != nil {
-			r := cursor.Value.(runeWithSize).r
-			res = append(res, r)
-			if r == EOF {
-				return res
-			}
-			cursor = cursor.Next()
+	}
+
+	res := make([]rune, 0, n)
+	for i := 0; i < n; i++ {
+		r := rd.buffer[rd.current+i]
+		if r == badRune {
+			r = utf8.RuneError
+		}
+		res = append(res, r)
+		if r == EOF {
+			break
 		}
 	}
 	return res
+}
+
+func (rd *Reader) haveEOF() bool {
+	return rd.current < len(rd.buffer) && rd.buffer[len(rd.buffer)-1] == EOF
 }

--- a/buffruneio_test.go
+++ b/buffruneio_test.go
@@ -133,7 +133,6 @@ func TestForget(t *testing.T) {
 	if rd.UnreadRune() != ErrNoRuneToUnread {
 		t.Fatal("no rune should be available")
 	}
-	assumeRune(t, rd, 'i') // a bug!
 	assumeRune(t, rd, 'o')
 }
 
@@ -252,8 +251,7 @@ func benchmarkRead(b *testing.B, count int, forget bool) {
 				b.Fatal(err)
 			}
 			if r != EOF {
-				// Forget is buggy, don't crash
-				// b.Fatalf("missing EOF - %q", r)
+				b.Fatalf("missing EOF - %q", r)
 			}
 			if repeat == count-1 {
 				break

--- a/buffruneio_test.go
+++ b/buffruneio_test.go
@@ -1,9 +1,11 @@
 package buffruneio
 
 import (
+	"reflect"
 	"runtime/debug"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func assertNoError(t *testing.T, err error) {
@@ -27,14 +29,19 @@ func assumeRunesArray(t *testing.T, expected []rune, got []rune) {
 
 func assumeRune(t *testing.T, rd *Reader, r rune) {
 	gotRune, size, err := rd.ReadRune()
-	assertNoError(t, err)
-	if gotRune != r {
-		t.Fatal("got", string(gotRune),
-			"(", []byte(string(gotRune)), ")",
-			"expected", string(r),
-			"(", []byte(string(r)), ")")
-		t.Fatal("got size", size,
-			"expected", len([]byte(string(r))))
+	wantSize := utf8.RuneLen(r)
+	if wantSize < 0 {
+		wantSize = 0
+	}
+	if gotRune != r || size != wantSize || err != nil {
+		t.Fatalf("ReadRune() = %q, %d, %v, wanted %q, %d, nil", gotRune, size, err, r, wantSize)
+	}
+}
+
+func assumeBadRune(t *testing.T, rd *Reader) {
+	gotRune, size, err := rd.ReadRune()
+	if gotRune != utf8.RuneError || size != 1 || err != nil {
+		t.Fatalf("ReadRune() = %q, %d, %v, wanted %q, 1, nil", gotRune, size, err, utf8.RuneError)
 	}
 }
 
@@ -58,6 +65,29 @@ func TestMultipleEOF(t *testing.T) {
 	assumeRune(t, rd, EOF)
 }
 
+func TestBadRunes(t *testing.T) {
+	s := "ab\xff\ufffd\xffcd"
+	rd := NewReader(strings.NewReader(s))
+
+	assumeRune(t, rd, 'a')
+	assumeRune(t, rd, 'b')
+	assumeBadRune(t, rd)
+	assumeRune(t, rd, utf8.RuneError)
+	assumeBadRune(t, rd)
+	assumeRune(t, rd, 'c')
+	assumeRune(t, rd, 'd')
+
+	for i := 0; i < 6; i++ {
+		assertNoError(t, rd.UnreadRune())
+	}
+	assumeRune(t, rd, 'b')
+	assumeBadRune(t, rd)
+	assumeRune(t, rd, utf8.RuneError)
+	assumeBadRune(t, rd)
+	assumeRune(t, rd, 'c')
+	assumeRune(t, rd, 'd')
+}
+
 func TestUnread(t *testing.T) {
 	s := "ab"
 	rd := NewReader(strings.NewReader(s))
@@ -70,28 +100,58 @@ func TestUnread(t *testing.T) {
 }
 
 func TestUnreadEOF(t *testing.T) {
-	s := ""
+	s := "x"
 	rd := NewReader(strings.NewReader(s))
 
 	_ = rd.UnreadRune()
+	assumeRune(t, rd, 'x')
 	assumeRune(t, rd, EOF)
 	assumeRune(t, rd, EOF)
 	assertNoError(t, rd.UnreadRune())
 	assumeRune(t, rd, EOF)
+	assertNoError(t, rd.UnreadRune())
+	assertNoError(t, rd.UnreadRune())
+	assumeRune(t, rd, EOF)
+	assumeRune(t, rd, EOF)
+	assertNoError(t, rd.UnreadRune())
+	assertNoError(t, rd.UnreadRune())
+	assertNoError(t, rd.UnreadRune())
+	assumeRune(t, rd, 'x')
+	assumeRune(t, rd, EOF)
+	assumeRune(t, rd, EOF)
 }
 
 func TestForget(t *testing.T) {
-	s := "hello"
+	s := "helio"
 	rd := NewReader(strings.NewReader(s))
 
 	assumeRune(t, rd, 'h')
 	assumeRune(t, rd, 'e')
 	assumeRune(t, rd, 'l')
-	assumeRune(t, rd, 'l')
+	assumeRune(t, rd, 'i')
 	rd.Forget()
 	if rd.UnreadRune() != ErrNoRuneToUnread {
 		t.Fatal("no rune should be available")
 	}
+	assumeRune(t, rd, 'i') // a bug!
+	assumeRune(t, rd, 'o')
+}
+
+func TestForgetAfterUnread(t *testing.T) {
+	s := "helio"
+	rd := NewReader(strings.NewReader(s))
+
+	assumeRune(t, rd, 'h')
+	assumeRune(t, rd, 'e')
+	assumeRune(t, rd, 'l')
+	assumeRune(t, rd, 'i')
+	assertNoError(t, rd.UnreadRune())
+	rd.Forget()
+	if rd.UnreadRune() != ErrNoRuneToUnread {
+		t.Fatal("no rune should be available")
+	}
+	assumeRune(t, rd, 'i')
+	assumeRune(t, rd, 'o')
 }
 
 func TestForgetEmpty(t *testing.T) {
@@ -134,12 +194,73 @@ func TestPeek(t *testing.T) {
 }
 
 func TestPeekLarge(t *testing.T) {
-	s := "abcdefg"
+	s := "abcdefg☺\xff☹"
 	rd := NewReader(strings.NewReader(s))
 
 	runes := rd.PeekRunes(100)
-	if len(runes) != len(s)+1 {
-		t.Fatal("incorrect number of runes", len(runes))
+	want := []rune{'a', 'b', 'c', 'd', 'e', 'f', 'g', '☺', utf8.RuneError, '☹', EOF}
+	if !reflect.DeepEqual(runes, want) {
+		t.Fatalf("PeekRunes(100) = %q, want %q", runes, want)
 	}
-	assumeRunesArray(t, []rune{'a', 'b', 'c', 'd', 'e', 'f', 'g', EOF}, runes)
+}
+
+var bigString = strings.Repeat("abcdefghi☺\xff☹", 1024) // 16 kB
+
+const bigStringRunes = 12 * 1024 // 12k runes
+
+func BenchmarkRead16K(b *testing.B) {
+	// Read 16K with no unread, no forget.
+	benchmarkRead(b, 1, false)
+}
+
+func BenchmarkReadForget16K(b *testing.B) {
+	// Read 16K, forgetting every 128 runes.
+	benchmarkRead(b, 1, true)
+}
+
+func BenchmarkReadRewind16K(b *testing.B) {
+	// Read 16K, unread all, read that 16K again.
+	benchmarkRead(b, 2, false)
+}
+
+func benchmarkRead(b *testing.B, count int, forget bool) {
+	if len(bigString) != 16*1024 {
+		b.Fatal("wrong length for bigString")
+	}
+	sr0 := strings.NewReader(bigString)
+	sr := new(strings.Reader)
+	b.SetBytes(int64(len(bigString)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		*sr = *sr0
+		rd := NewReader(sr)
+		for repeat := 0; repeat < count; repeat++ {
+			for j := 0; j < bigStringRunes; j++ {
+				r, _, err := rd.ReadRune()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if r == EOF {
+					b.Fatal("unexpected EOF")
+				}
+				if forget && j%128 == 127 {
+					rd.Forget()
+				}
+			}
+			r, _, err := rd.ReadRune()
+			if err != nil {
+				b.Fatal(err)
+			}
+			if r != EOF {
+				// Forget is buggy, don't crash
+				// b.Fatalf("missing EOF - %q", r)
+			}
+			if repeat == count-1 {
+				break
+			}
+			for rd.UnreadRune() == nil {
+				// keep unreading
+			}
+		}
+	}
 }


### PR DESCRIPTION
Hi,

I noticed that a lot of Go packages are using this package for buffered rune input, and it seemed inefficient to be using container/list instead of a slice, so I changed the implementation to use a slice. I found and fixed a bug in Forget in the process, and I revised the doc comments a bit.

Thanks for writing a package that so many people want to use. :-)

```
name             old time/op    new time/op    delta
Read16K-8           886µs ± 1%     200µs ± 0%   -77.47%  (p=0.000 n=9+8)
ReadForget16K-8     944µs ± 4%     191µs ± 4%   -79.82%  (p=0.000 n=10+9)
ReadRewind16K-8     987µs ± 1%     278µs ± 1%   -71.87%  (p=0.000 n=9+10)

name             old speed      new speed      delta
Read16K-8        18.5MB/s ± 1%  82.0MB/s ± 1%  +343.56%  (p=0.000 n=9+9)
ReadForget16K-8  17.4MB/s ± 4%  86.0MB/s ± 4%  +395.53%  (p=0.000 n=10+9)
ReadRewind16K-8  16.6MB/s ± 1%  59.0MB/s ± 1%  +255.49%  (p=0.000 n=9+10)

name             old alloc/op   new alloc/op   delta
Read16K-8           791kB ± 0%     208kB ± 0%   -73.73%  (p=0.002 n=8+10)
ReadForget16K-8     791kB ± 0%       5kB ± 0%   -99.34%  (p=0.000 n=10+10)
ReadRewind16K-8     791kB ± 0%     208kB ± 0%   -73.74%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
Read16K-8           24.6k ± 0%      0.0k ± 0%   -99.94%  (p=0.000 n=10+10)
ReadForget16K-8     24.6k ± 0%      0.0k ± 0%   -99.99%  (p=0.000 n=10+10)
ReadRewind16K-8     24.6k ± 0%      0.0k ± 0%   -99.94%  (p=0.000 n=10+10)
```

https://perf.golang.org/search?q=upload:20180119.1